### PR TITLE
Fix camera angle interpolation (camera jitter)

### DIFF
--- a/src/main/java/namecorp/camera_lock_on/client/Camera_lock_onClient.java
+++ b/src/main/java/namecorp/camera_lock_on/client/Camera_lock_onClient.java
@@ -27,7 +27,7 @@ public class Camera_lock_onClient implements ClientModInitializer {
     @Override
     public void onInitializeClient() {
         ClientTickEvents.END_CLIENT_TICK.register(new HudTickDeltaEvent());
-        WorldRenderEvents.LAST.register(new LockOnEvent());
+        WorldRenderEvents.START.register(new LockOnEvent());
         HudRenderCallback.EVENT.register(new HudRenderEvent());
     }
 

--- a/src/main/java/namecorp/camera_lock_on/client/events/LockOnEvent.java
+++ b/src/main/java/namecorp/camera_lock_on/client/events/LockOnEvent.java
@@ -14,9 +14,9 @@ import net.minecraft.util.math.*;
 
 import static namecorp.camera_lock_on.client.Camera_lock_onClient.*;
 
-public class LockOnEvent implements WorldRenderEvents.Last {
+public class LockOnEvent implements WorldRenderEvents.Start {
     @Override
-    public void onLast(WorldRenderContext last) {
+    public void onStart(WorldRenderContext last) {
         MinecraftClient client = MinecraftClient.getInstance();
         ClientPlayerEntity player = client.player;
 
@@ -58,9 +58,6 @@ public class LockOnEvent implements WorldRenderEvents.Last {
                 float lockedYaw;
                 float lockedPitch;
 
-                float currentYaw = player.getYaw(tickDelta);
-                float currentPitch = player.getPitch(tickDelta);
-
                 double deltaX = Math.abs(targetPos.x - playerPos.x);
                 double deltaY = targetPos.y - playerPos.y;
                 double deltaZ = Math.abs(targetPos.z - playerPos.z);
@@ -92,26 +89,10 @@ public class LockOnEvent implements WorldRenderEvents.Last {
                     }
                 }
 
-
                 lockedPitch = (float) thetaDegreesXY - 90;
 
-                if (lockedYaw < currentYaw - 180f) {
-                    lockedYaw += 360f;
-                }
-
-                if (lockedYaw > currentYaw + 180f) {
-                    lockedYaw -= 360f;
-                }
-
-                float yawDelta = cameraDelta;
-                float pitchDelta = cameraDelta;
-
-                if(player.input.jumping) {
-                    pitchDelta = cameraDelta/5f;
-                }
-
-                player.setYaw(MathHelper.lerp(yawDelta, currentYaw, lockedYaw));
-                player.setPitch(MathHelper.lerp(pitchDelta, currentPitch, lockedPitch));
+                player.setYaw(MathHelper.lerpAngleDegrees(tickDelta, player.prevYaw, lockedYaw));
+                player.setPitch(MathHelper.lerpAngleDegrees(tickDelta, player.prevPitch, lockedPitch));
             }
         } else {
             lockedEntity = null;

--- a/src/main/java/namecorp/camera_lock_on/client/events/LockOnEvent.java
+++ b/src/main/java/namecorp/camera_lock_on/client/events/LockOnEvent.java
@@ -20,47 +20,14 @@ public class LockOnEvent implements WorldRenderEvents.Last {
         MinecraftClient client = MinecraftClient.getInstance();
         ClientPlayerEntity player = client.player;
 
-        float tickDelta = worldRenderContext.tickCounter().getTickDelta(false);
-        
         if(player != null && client.world != null) {
             if(lockOnKeyBind.wasPressed()) {
-                HitResult hit = raycastCrosshair(client.cameraEntity, 500.0f, tickDelta);
+                HitResult hit = raycastCrosshair(client.cameraEntity, 500.0f, last.tickCounter().getTickDelta(true));
                 if(lockedEntity != null) {
                     lockedEntity = null;
                 } else {
                     if(hit instanceof EntityHitResult && ((EntityHitResult) hit).getEntity() instanceof LivingEntity) {
                         lockedEntity = (LivingEntity) ((EntityHitResult) hit).getEntity();
-                    } else {
-                        float currYaw = player.getYaw(tickDelta);
-                        float tempYaw = currYaw;
-                        float savedYaw = 999999;
-
-                        LivingEntity temp = null;
-
-                        for(int i = -20; i < 20; i++) {
-                            tempYaw = currYaw + Math.abs(i);
-                            player.setYaw(currYaw+i);
-                            HitResult hit1 = raycastCrosshair(client.cameraEntity, 500.0f, tickDelta);
-
-                            if(hit1 instanceof EntityHitResult && ((EntityHitResult) hit1).getEntity() instanceof LivingEntity) {
-                                LivingEntity newEntity = (LivingEntity) ((EntityHitResult) hit1).getEntity();
-                                if(temp == null) {
-                                    temp = (LivingEntity) ((EntityHitResult) hit1).getEntity();
-                                } else {
-                                    if(tempYaw < savedYaw) {
-                                        temp = newEntity;
-                                        savedYaw = tempYaw;
-                                    }
-                                }
-
-                            }
-                        }
-
-                        if(temp != null) {
-                            lockedEntity = temp;
-                        }
-
-                        player.setYaw(currYaw);
                     }
                 }
             }
@@ -85,6 +52,8 @@ public class LockOnEvent implements WorldRenderEvents.Last {
             if (lockedEntity != null) {
                 Vec3d targetPos = lockedEntity.getPos();
                 Vec3d playerPos = player.getPos();
+
+                float tickDelta = last.tickCounter().getTickDelta(true);
 
                 float lockedYaw;
                 float lockedPitch;
@@ -139,14 +108,6 @@ public class LockOnEvent implements WorldRenderEvents.Last {
 
                 if(player.input.jumping) {
                     pitchDelta = cameraDelta/5f;
-                }
-
-                if(client.getCurrentFps() > 200) {
-                    int i = client.getCurrentFps()/200;
-                    for(int j = 0; j < i; j++) {
-                        yawDelta = yawDelta/2;
-                        pitchDelta = pitchDelta/2;
-                    }
                 }
 
                 player.setYaw(MathHelper.lerp(yawDelta, currentYaw, lockedYaw));


### PR DESCRIPTION
This PR fixes the camera angle interpolation (or jitter as we called), as discussed in #2. It would also be a good idea to disable mouse movement inputs while lock-on is active, or disable the lock-on when the mouse is moved.